### PR TITLE
The patch

### DIFF
--- a/boke.py
+++ b/boke.py
@@ -8,23 +8,24 @@ from bokego.nnet import PolicyNet, ValueNet, PolicyNet_v2
 from bokego.mcts import Go_MCTS 
 from bokego import PKG_PATH 
 
-USE_CUDA = False
 torch.set_grad_enabled(False)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description = "BokeGo v0.3 GTP Engine")
-    parser.add_argument("-t", metavar="SEC", type = float, dest = 't', 
+    parser.add_argument("-t", metavar="SEC", type = float, dest = 't',
                         help = "time limit in seconds for each move", default = 10.0)
     parser.add_argument("-r", dest = 'r', type = int, help = "number of rollouts per move")
     parser.add_argument("-p", metavar="PATH", type = str, dest = 'p', help = "path to policy weights",
                         default = os.path.join( "data", "weights", "policy_0.pt"))
     parser.add_argument("-v", metavar="PATH", type = str, dest = 'v', help = "path to value weights", 
-                        default = os.path.join("data","weights", "value_1.pt")) 
-    parser.add_argument("--simulate", action = "store_true", 
+                        default = os.path.join("data","weights", "value_1.pt"))
+    parser.add_argument("-g", "--gpu", action = "store_true", 
+                        help = "Accelerate NN forward by GPU.")
+    parser.add_argument("--simulate", action = "store_true",
                         help = "enable simulations to end of game (slow)")
     args = parser.parse_args()
 
-    device = torch.device("cuda" if USE_CUDA else "cpu")
+    device = torch.device("cuda" if (args.gpu and torch.cuda.is_available()) else "cpu")
 
     pi = PolicyNet()
     p_weight = torch.load(args.p, map_location= device)

--- a/bokego/gtp.py
+++ b/bokego/gtp.py
@@ -342,8 +342,8 @@ class GTP(MCTS):
         else:
             condition = self.surrender 
         if condition:
-                self.running = False
-                return go.RESIGN
+            self.running = False
+            return go.RESIGN
 
         if self.time_lim:
             self.timed_rollout(self.time_lim)

--- a/bokego/mcts.py
+++ b/bokego/mcts.py
@@ -61,7 +61,7 @@ class MCTS:
         self.expand_thresh = kwargs.get("expand_thresh",100)
         self.branch_num = kwargs.get("branch_num")
         self.exploration_weight = kwargs.get("exploration_weight", 4.0)
-        self.noise_weight = kwargs.get("noise_weight", 0.25)
+        self.noise_weight = kwargs.get("noise_weight", 0)
         if self.no_sim:
             self.value_net_weight = 1.0
         elif self.value_net is None:
@@ -377,6 +377,7 @@ class Go_MCTS(go.Game):
                                 self, 
                                 fts = self.features,
                                 device = self.tree.device)
+            dist.probs = dist.probs.to(torch.device("cpu"))
             MCTS._dist_cache[self] = dist 
         return dist
 


### PR DESCRIPTION
1. Fix MCTS bug caused by data on the GPU memory. We forced the policy result(also in the dist cache) to go to CPU device. 
2. Add GPU option. Now it is more easy to use GPU.
3. It seems that the noise is never used.  Change the noise parameter to zero in order to avoid bad move.