### PR TITLE
Fix some GTP outputs.

### DIFF
--- a/bokego/gtp.py
+++ b/bokego/gtp.py
@@ -286,7 +286,7 @@ class GTP(MCTS):
                 outpath = cmd[1]
             else:
                 outpath = os.path.join(os.getcwd(), "bokego.sgf")
-            out = go.write_sgf(self._move_history, outpath)
+            out = go.write_sgf(self._move_history, outpath, komi=self.root.komi)
             valid = True
 
         elif cmd[0] == "loadsgf":


### PR DESCRIPTION
1. Support for setting variant komi. Yet, the value network will not work as accurately compared to variant komi, but final score will be better.
2. The printsgf will output variant komi.
3. Fix the bug that the final score GTP outputs is not correct.