### PR TITLE
Fix analyze verbose bug and some wired result.

### DIFF
--- a/bokego/gtp.py
+++ b/bokego/gtp.py
@@ -385,6 +385,7 @@ class GTP(MCTS):
             best_mvs = sorted(variations.keys(), 
                         key = lambda n: self.N[n])
             if self._input[0] is not None:
+                yield "\n"
                 break
             out = ""
             for n in best_mvs[-k:]:


### PR DESCRIPTION
Fix the analyzing mode bug. It can work on sabaki now.

But I fonud some wired results. The above game is boke(black) vs. my bot(white). We can see that boke thinks the itself winrate is 99.8% in above position. 

![Screenshot from 2021-11-04 01-06-26](https://user-images.githubusercontent.com/39462842/140127994-4a9bd965-a20d-4299-8e6c-19c7db6b1bde.png)

Now we watch the white side, boke also thinks my bot winrate is 99.9%. Seem that some bugs is in MCTS.

![Screenshot from 2021-11-04 01-04-02](https://user-images.githubusercontent.com/39462842/140131149-bc6fa0c5-cc13-40c5-b5e1-75d1b1e064c0.png)
