### PR TITLE
Fix MCTS bug.

### DIFF
--- a/bokego/gtp.py
+++ b/bokego/gtp.py
@@ -393,7 +393,7 @@ class GTP(MCTS):
                 variation = go.unsquash( [m.last_move for m in variations[n] ]) 
                 prior = self.root.dist.probs[n.last_move]
                 out += f"info move {mv} visits {self.N[n]} "\
-                       f"winrate {10000*n.winrate:.0f} "\
+                       f"winrate {10000*(1-n.winrate):.0f} "\
                        f"prior {10000*prior:.0f} "\
                       "pv " + " ".join(variation) + " "
             yield out + "\n"

--- a/bokego/mcts.py
+++ b/bokego/mcts.py
@@ -55,7 +55,7 @@ class MCTS:
             raise TypeError("Missing required keywork argument: 'policy_net'")
         self.policy_net = policy_net
         self.value_net = value_net
-        self.no_sim = kwargs.get("no_sim", False)
+        self.no_sim = kwargs.get("no_sim", True)
         if self.value_net is None and self.no_sim:
             raise TypeError("Keyword argument 'value_net' is required for no simulation mode")
         self.expand_thresh = kwargs.get("expand_thresh",100)
@@ -214,6 +214,7 @@ class MCTS:
                 reward = -reward 
             if self.value_net != None:
                 self.V[node] += leaf_val
+                leaf_val = -leaf_val
 
     def _puct_select(self, node):
         "Select a child of node with PUCT"
@@ -226,7 +227,7 @@ class MCTS:
             avg_reward = 0 if self.N[n] == 0 else \
                     ((1 - self.value_net_weight) * self.Q[n]
                      + self.value_net_weight * self.V[n]) / self.N[n]
-            return avg_reward + (self.exploration_weight
+            return -avg_reward + (self.exploration_weight
                     * last_move_prob 
                     * sqrt(total_visits) / (1 + self.N[n]))
 


### PR DESCRIPTION
Fix the MCTS updating, puct algorithm bugs and disable the random simulation. Now quit stronger than before.

The above game is GnuGO(black, Lv10) vs boke(white, 1 sec per move). We can see the value evaluation likes good.

![Screenshot from 2021-11-05 00-02-40](https://user-images.githubusercontent.com/39462842/140375257-9a890901-c27e-4283-b375-c18d74098f39.png)



